### PR TITLE
Fix status_bar_height_default not found

### DIFF
--- a/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
@@ -20,5 +20,5 @@
     <dimen name="keyguard_carrier_text_margin">22dp</dimen>
 
     <!-- Height of the status bar header bar when on Keyguard -->
-    <dimen name="status_bar_header_height_keyguard">@*android:dimen/status_bar_height_default</dimen>
+    <dimen name="status_bar_header_height_keyguard">@*android:dimen/status_bar_height</dimen>
 </resources>


### PR DESCRIPTION
This supposed to fix the "status_bar_height_default not found" error when building AOSP 12.1.0_r26. Please review bc even if I managed to build ROM successfully, my phone stuck on black screen and doesn't boot.

https://android.googlesource.com/device/google/raviole/+/b7cc9eee54b0601279f806167f60167324b52592%5E%21/#F1